### PR TITLE
Refactor email confirmation and simplify email sending

### DIFF
--- a/WPHBookingSystem.Application/UseCases/Bookings/CreateBookingUseCase.cs
+++ b/WPHBookingSystem.Application/UseCases/Bookings/CreateBookingUseCase.cs
@@ -102,7 +102,7 @@ namespace WPHBookingSystem.Application.UseCases.Bookings
                 };
 
                 // Send confirmation email
-                await _emailService.SendBookingConfirmationAsync(bookingDto, dto.EmailAddress, dto.Guests.ToString());
+                await _emailService.SendBookingConfirmationAsync(bookingDto, dto.EmailAddress, dto.GuestName);
 
                 // Return success result with booking information
                 return Result<BookingCreatedDto>.Success(

--- a/WPHBookingSystem.Infrastructure/Services/EmailService.cs
+++ b/WPHBookingSystem.Infrastructure/Services/EmailService.cs
@@ -113,34 +113,7 @@ namespace WPHBookingSystem.Infrastructure.Services
             try
             {
 
-                await _emailService.SendAsync(toEmail,subject,htmlBody,isHtml:true);
-                //var message = new MimeMessage();
-                //message.From.Add(new MailboxAddress(_emailSettings.FromName, _emailSettings.FromEmail));
-                //message.To.Add(new MailboxAddress("", toEmail));
-                //message.Subject = subject;
-
-                //var bodyBuilder = new BodyBuilder
-                //{
-                //    HtmlBody = htmlBody
-                //};
-                //message.Body = bodyBuilder.ToMessageBody();
-
-                //using var client = new SmtpClient();
-                
-                //// Configure SSL/TLS based on settings
-                //var secureSocketOptions = _emailSettings.EnableSsl ? SecureSocketOptions.StartTls : SecureSocketOptions.None;
-                
-                //await client.ConnectAsync(_emailSettings.SmtpHost, _emailSettings.SmtpPort, secureSocketOptions);
-
-                //// Authenticate if required
-                //if (_emailSettings.EnableAuthentication && !string.IsNullOrEmpty(_emailSettings.Username))
-                //{
-                //    await client.AuthenticateAsync(_emailSettings.Username, _emailSettings.Password);
-                //}
-
-                //await client.SendAsync(message);
-                //await client.DisconnectAsync(true);
-                
+                await _emailService.SendAsync(toEmail,subject,htmlBody,isHtml:true);                
                 _logger.LogInformation("Email sent successfully to {ToEmail}", toEmail);
                 return true;
             }


### PR DESCRIPTION
Updated `CreateBookingUseCase.cs` to use `dto.GuestName` for email confirmation instead of `dto.Guests.ToString()`. Removed unnecessary commented-out code in `EmailService.cs` and streamlined the email-sending process by directly invoking `_emailService.SendAsync`, while adding a success log message.