### PR TITLE
Update API routes for booking and contact controllers

### DIFF
--- a/WPHBookingSystem.WebUI/Controllers/BookingController.cs
+++ b/WPHBookingSystem.WebUI/Controllers/BookingController.cs
@@ -24,7 +24,7 @@ namespace WPHBookingSystem.WebUI.Controllers
     /// </summary>
     [Authorize]
     [ApiController]
-    [Route("api/[controller]")]
+    [Route("api/bookings")]
     public class BookingController : ControllerBase
     {
         private readonly IBookingSystemFacade _facade;

--- a/WPHBookingSystem.WebUI/Controllers/ContactMessageController.cs
+++ b/WPHBookingSystem.WebUI/Controllers/ContactMessageController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Authorization;
 namespace WPHBookingSystem.WebUI.Controllers
 {
     [ApiController]
-    [Route("api/[controller]")]
+    [Route("api/contact-messages")]
     public class ContactMessageController : ControllerBase
     {
         private readonly IBookingSystemFacade _facade;

--- a/WPHBookingSystem.WebUI/Controllers/RoomController.cs
+++ b/WPHBookingSystem.WebUI/Controllers/RoomController.cs
@@ -27,7 +27,7 @@ namespace WPHBookingSystem.WebUI.Controllers
     /// and provides both public and administrative room management capabilities.
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
+    [Route("api/rooms")]
     public class RoomController : ControllerBase
     {
         private readonly IBookingSystemFacade _bookingSystemFacade;


### PR DESCRIPTION
Refactor the route attributes in `BookingController`, `ContactMessageController`, and `RoomController` to use more descriptive paths. The routes have been changed from `api/[controller]` to `api/bookings`, `api/contact-messages`, and `api/rooms`, improving the clarity of the API endpoints.