### PR TITLE
Use string interpolation for Guest Name in EmailService

### DIFF
--- a/WPHBookingSystem.Infrastructure/Services/EmailService.cs
+++ b/WPHBookingSystem.Infrastructure/Services/EmailService.cs
@@ -170,7 +170,7 @@ namespace WPHBookingSystem.Infrastructure.Services
             html.AppendLine("            <div class=\"booking-details\">");
             html.AppendLine("                <h3>Booking Details</h3>");
             html.AppendLine("                <table style=\"width: 100%; border-collapse: collapse;\">");
-            html.AppendLine("                    <tr><td style=\"font-weight: bold; padding: 8px;\">Guest Name:</td><td style=\"padding: 8px;\">{guestName}</td></tr>");
+            html.AppendLine($"                    <tr><td style=\"font-weight: bold; padding: 8px;\">Guest Name:</td><td style=\"padding: 8px;\">{guestName}</td></tr>");
             html.AppendLine($"                    <tr><td style=\"font-weight: bold; padding: 8px;\">Room:</td><td style=\"padding: 8px;\">{booking.RoomName}</td></tr>");
             html.AppendLine($"                    <tr><td style=\"font-weight: bold; padding: 8px;\">Number of Guests:</td><td style=\"padding: 8px;\">{booking.Guests}</td></tr>");
             html.AppendLine($"                    <tr><td style=\"font-weight: bold; padding: 8px;\">Check-in:</td><td style=\"padding: 8px;\">{booking.CheckIn:dddd, MMMM dd, yyyy}</td></tr>");


### PR DESCRIPTION
Updated the `Guest Name` row in `EmailService.cs` to use string interpolation (`$"{guestName}"`) instead of a plain string (`"{guestName}"`). This ensures the `guestName` variable is properly evaluated and included in the HTML output. The change improves code readability and consistency with other rows in the table that already use string interpolation.